### PR TITLE
docs: replace jq priority checks with kubectl jsonpath/custom-columns

### DIFF
--- a/exercises/22-priorityclass/README.md
+++ b/exercises/22-priorityclass/README.md
@@ -64,8 +64,13 @@ k get priorityclass -o wide
 
 # Check pod priority
 k get pod -o wide
-k get pod critical-app -o json | jq '.spec.priorityClassName, .spec.priority'
-k get pod background-job -o json | jq '.spec.priorityClassName, .spec.priority'
+
+# Fast priority check (all pods in one table)
+k get pod -o custom-columns=NAME:.metadata.name,CLASS:.spec.priorityClassName,PRIORITY:.spec.priority
+
+# Single pod checks (exam-safe, no jq needed)
+k get pod critical-app -o jsonpath='{.spec.priorityClassName}{" "}{.spec.priority}{"\n"}'
+k get pod background-job -o jsonpath='{.spec.priorityClassName}{" "}{.spec.priority}{"\n"}'
 
 # Check pod scheduling
 k describe pod critical-app


### PR DESCRIPTION
## What does this PR do?

Replaces `jq`-based verification commands in Exercise 22 (PriorityClass) with native `kubectl` output options (`custom-columns` and `jsonpath`).

This makes the verify steps faster and more exam-friendly by removing the external `jq` dependency.

## Type of change

- [x] Documentation update (README, comments, wording)
- [ ] Bug fix (broken command, invalid YAML, dead link)
- [ ] New content (exercise, skeleton, troubleshooting scenario)
- [ ] Chore (CI, tooling, repo housekeeping)

## Which CKA domain does this relate to?

- [ ] Storage (10%)
- [ ] Troubleshooting (30%)
- [x] Workloads & Scheduling (15%)
- [ ] Cluster Architecture, Installation & Configuration (25%)
- [ ] Services & Networking (20%)
- [ ] N/A

## Checklist

- [x] I ran `bash scripts/validate-local.sh` with no errors
- [x] I tested commands/YAML on Kubernetes v1.35
- [x] I did not include real CKA exam questions
- [x] I followed the writing style (first-person, casual, no emojis, no AI filler)