### PR TITLE
docs: add practical vim keys used on exam day

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ CKA-Certified-Kubernetes-Administrator/
 - [YAML Templates Quick Reference](#yaml-skeletons--write-these-from-memory)
 - [Exam Day Strategy — Time Allocation](#exam-day-strategy--time-allocation)
 - [Mistakes That Will Fail You on the CKA](#mistakes-that-will-fail-you-on-the-cka)
+- [Vim Keys I Actually Used on Exam Day](#vim-keys-i-actually-used-on-exam-day)
 - [Troubleshooting Decision Flowchart](#troubleshooting-decision-flowchart)
 - [CKA Exam Day Checklist](#cka-exam-day-checklist)
 
@@ -1965,6 +1966,41 @@ k create rolebinding my-binding \
   --serviceaccount=my-ns:my-sa \
   -n my-ns
 ```
+
+---
+
+## Vim Keys I Actually Used on Exam Day
+
+Not a vim guide, just the handful I kept hitting. If you already know vim, skip this.
+
+Vim has two modes that matter here: **insert mode** (where you type text like a normal editor) and **normal mode** (where keys are commands). You start in normal mode. Press `i` to enter insert mode, press `Esc` to get back to normal mode. Almost every shortcut below is a normal mode command, so hit `Esc` first if you are not sure where you are.
+
+**Opening and saving**
+
+- `vim <file>` to open the file. You start in normal mode.
+- `i` (normal mode) to enter insert mode and start typing.
+- `Esc` to leave insert mode and go back to normal mode.
+- `:wq` (normal mode) to save and quit. `:q!` to bail without saving.
+
+**Moving around (normal mode)**
+
+- `A` jumps to the end of the current line and drops you into insert mode. Handy for adding to an existing line without arrow-keying across.
+- `$` moves the cursor to the end of the line without entering insert mode.
+- `0` moves to the start of the line.
+- `gg` jumps to the top of the file, `G` jumps to the bottom.
+- `H` top of the visible screen, `M` middle, `L` bottom.
+- `/word` then `Enter` to search, `n` for the next match.
+
+**Editing (normal mode)**
+
+- `<number>dd` deletes that many lines. `5dd` wipes 5 lines at once. I used this constantly to clean up the junk that `kubectl ... --dry-run=client -o yaml` adds (status blocks, creationTimestamp, empty resources).
+- `dd` on its own deletes the current line.
+- `u` to undo.
+
+That is all I needed. Anything fancier I would look up, but on exam day I never had to.
+
+[Back to top](#table-of-contents)
+
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

## What does this PR do?

Adds a new standalone section in `README.md`: **"Vim Keys I Actually Used on Exam Day"**.

The section is intentionally short and exam-focused:
- quick insert vs normal mode reminder
- only the Vim keys that are useful under CKA time pressure (open/save, movement, search, line delete, undo)
- practical note on using `<number>dd` to clean generated YAML quickly

Also adds a Table of Contents entry for the new section.

## Type of change

- [ ] Bug fix (broken command, invalid YAML, dead link)
- [ ] New content (exercise, skeleton, troubleshooting scenario)
- [x] Documentation update (README, comments, wording)
- [ ] Chore (CI, tooling, repo housekeeping)

## Which CKA domain does this relate to?

- [ ] Storage (10%)
- [ ] Troubleshooting (30%)
- [ ] Workloads & Scheduling (15%)
- [ ] Cluster Architecture, Installation & Configuration (25%)
- [ ] Services & Networking (20%)
- [x] N/A

## Checklist

- [x] I ran `bash scripts/validate-local.sh` with no errors
- [x] I tested any commands I added on Kubernetes v1.35
- [x] I did not include real CKA exam questions
- [x] I followed the writing style (first-person, casual, no emojis, no AI filler)





Context: this addition comes from exam/practice experience and is meant to reduce YAML editing mistakes under time pressure.