### PR TITLE
fix: correct HPA question 9 and solution

### DIFF
--- a/mock-exams/MOCK-EXAM-01-SOLUTIONS.md
+++ b/mock-exams/MOCK-EXAM-01-SOLUTIONS.md
@@ -390,9 +390,10 @@ Verify HPA:
 ```bash
 k get hpa -n production
 k describe hpa web-app-hpa -n production
+kubectl top pods -n production   # confirms metrics-server is working
 ```
 
-**Key insight:** avgUtilization 70 means scale up when average CPU across all replicas exceeds 70%. It will scale down when it drops below the default threshold (usually 30% by default, but can be tuned). HPA requires metrics-server to be running.
+**Key insight:** HPA uses a single target utilization, not separate scale-up and scale-down thresholds. On each sync it computes `desiredReplicas = ceil(currentReplicas × currentCPU / targetCPU)` and scales in either direction within the `minReplicas`/`maxReplicas` bounds. A built-in tolerance (default 10%) prevents action on minor fluctuations, and scale-down aggressiveness can be tuned via `spec.behavior.scaleDown` (e.g. `stabilizationWindowSeconds`) rather than any fixed percentage. HPA requires `metrics-server` to be running.
 
 ---
 

--- a/mock-exams/MOCK-EXAM-01.md
+++ b/mock-exams/MOCK-EXAM-01.md
@@ -106,9 +106,7 @@ Enable API server audit logging and examine the logs for ConfigMap access patter
 
 ## Question 9: HPA and Application Scaling
 
-An application deployment runs with 2 replicas. Under load, it should scale up to 10 replicas when CPU reaches 70%. It should scale down to 2 replicas when CPU drops below 30%.
-
-Create a Horizontal Pod Autoscaler that enforces these constraints. The deployment is named `web-app` in namespace `production`.
+An application deployment named `web-app` in namespace `production` runs with 2 replicas. Create a Horizontal Pod Autoscaler that maintains an average CPU utilization of 70% across pods, scaling between a minimum of 2 and a maximum of 10 replicas.
 
 **Time: 7 minutes**
 


### PR DESCRIPTION
HPA uses a single target utilization, not separate scale-up/scale-down thresholds. Reworded Question 9 and updated the key insight to reflect the actual scaling algorithm.

## What does this PR do?
Fixes an inaccuracy in Question 9 and its solution. The original question described HPA as having a 70% scale-up threshold and a 30% scale-down threshold, and the solution's key insight reinforced this by mentioning a "default 30% scale-down threshold." Neither is how HPA works.

HPA uses a single target utilization and computes `desiredReplicas = ceil(currentReplicas × currentCPU / targetCPU)` on each sync, scaling in either direction within the `minReplicas`/`maxReplicas` bounds. A built-in 10% tolerance prevents action on minor fluctuations, and scale-down aggressiveness is tuned via `spec.behavior.scaleDown`, not a fixed percentage. Reference: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details

Changes:
- Reworded Question 9 to ask for a 70% target utilization between 2 and 10 replicas (which is what the existing YAML answer actually implements).
- Rewrote the Solution 9 key insight to describe the real scaling formula, mention the 10% tolerance, and point to `spec.behavior.scaleDown` as the correct way to tune scale-down behavior.
- Added `kubectl top pods -n production` to the verify step, since a broken metrics-server is the most common silent HPA failure.

## Type of change
- [x] Bug fix (broken command, invalid YAML, dead link)
- [ ] New content (exercise, skeleton, troubleshooting scenario)
- [x] Documentation update (README, comments, wording)
- [ ] Chore (CI, tooling, repo housekeeping)

## Which CKA domain does this relate to?
- [ ] Storage (10%)
- [ ] Troubleshooting (30%)
- [x] Workloads & Scheduling (15%)
- [ ] Cluster Architecture, Installation & Configuration (25%)
- [ ] Services & Networking (20%)
- [ ] N/A

## Checklist
- [x] I ran `bash scripts/validate-local.sh` with no errors
- [x] I tested any YAML/commands on Kubernetes v1.35
- [x] I did not include real CKA exam questions
- [x] I followed the writing style (first-person, casual, no emojis, no AI filler)
- [x] I used the repo aliases (`k`, `$do`, `$now`) where applicable
- [x] I verified all links point to existing files or valid URLs