### PR TITLE
docs: add patch and PriorityClass prod-speed tips to cheatsheet

### DIFF
--- a/cheatsheet/cka-cheatsheet.md
+++ b/cheatsheet/cka-cheatsheet.md
@@ -256,3 +256,39 @@ These are the commands that actually saved me time on the exam. The `$do` patter
 - `k delete pod <name> $now` — instant delete (no grace period)
 - `k run tmp --image=busybox:1.36 --rm -it -- sh` — throwaway debug pod
 - Copy from docs: kubernetes.io/docs/tasks/ has step-by-step for etcd, kubeadm, RBAC
+
+---
+
+## Patch Objects Fast (Without Rewriting YAML)
+
+When a question asks you to change one field, patching is usually faster and safer than opening a full manifest in vim or nano.
+
+Why patch is useful in exam conditions:
+- Updates only the field you target (lower chance of accidental YAML damage)
+- Faster than editing a long manifest
+- Easy to verify immediately with `jsonpath` or `describe`
+
+Official doc:
+- https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+
+I usually copy an example from the official doc first, then change only the field I need (for example, `priorityClassName`). This saves time and avoids patch JSON syntax mistakes.
+
+For image-only updates, `k set image` is usually safer than patching the entire `containers` list.
+
+```bash
+# Patch from file (good when patch is reused)
+kubectl patch deployment patch-demo --patch-file patch-file.json
+
+# Inline patch (good for one-off changes)
+kubectl patch deployment patch-demo --patch '{"spec":{"template":{"spec":{"containers":[{"name":"patch-demo-ctr-2","image":"redis"}]}}}}'
+
+# PriorityClass example
+# Create PriorityClass with a practical app value
+k create priorityclass high-priority --value=1000 --description="high priority"
+
+# Patch deployment pod template to use it
+k patch deployment busybox-logger -n priority -p '{"spec":{"template":{"spec":{"priorityClassName":"high-priority"}}}}'
+
+# Verify quickly
+k get deploy busybox-logger -n priority -o jsonpath='{.spec.template.spec.priorityClassName}{"\n"}'
+k describe deployment busybox-logger -n priority | grep -i "Priority Class"


### PR DESCRIPTION
## What does this PR do?

Adds a new section to `cheatsheet/cka-cheatsheet.md` called **"Patch Objects Fast (Without Rewriting YAML)"**.

This section explains when and why `kubectl patch` is useful in prod conditions, very handy for admins, links to the official Kubernetes patching doc, and adds practical examples for:
- patching Deployment fields quickly
- patching `priorityClassName` on a Deployment
- verifying changes fast with `jsonpath` and `describe`

It also includes a safety note that `k set image` is often safer for image-only updates than patching the full `containers` list.

## Type of change

- [ ] Bug fix (broken command, invalid YAML, dead link)
- [x] New content (exercise, skeleton, troubleshooting scenario)
- [x] Documentation update (README, comments, wording)
- [ ] Chore (CI, tooling, repo housekeeping)

## Which CKA domain does this relate to?

- [ ] Storage (10%)
- [ ] Troubleshooting (30%)
- [x] Workloads & Scheduling (15%)
- [ ] Cluster Architecture, Installation & Configuration (25%)
- [ ] Services & Networking (20%)
- [ ] N/A

## Checklist

- [x] I ran `bash scripts/validate-local.sh` with no errors
- [x] I tested any YAML/commands on Kubernetes v1.35
- [x] I did not include real CKA exam questions
- [x] I followed the writing style (first-person, casual, no emojis, no AI filler)
- [x] I used the repo aliases (`k`, `$do`, `$now`) where applicable
- [x] I verified all links point to existing files or valid URLs