### PR TITLE
docs: fix README pod resource limits example

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ k run nginx --image=nginx:1.27 --port=80
 k run nginx --image=nginx:1.27 --labels=app=web,tier=frontend
 
 # There is no direct command to run pod with resource limits, instead you can use dry-run then edit file or use --overrides arg
-kubectl run nginx --image=nginx --overrides='{"spec":{"containers":[{"name":"nginx","image":"nginx","resources":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}]}}'
+k run nginx --image=nginx --overrides='{"spec":{"containers":[{"name":"nginx","image":"nginx","resources":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}]}}'
 
 # Pod with environment variables
 k run nginx --image=nginx:1.27 --env=LOG_LEVEL=debug --env=APP_ENV=prod

--- a/README.md
+++ b/README.md
@@ -356,8 +356,8 @@ k run nginx --image=nginx:1.27 --port=80
 # Pod with labels
 k run nginx --image=nginx:1.27 --labels=app=web,tier=frontend
 
-# Pod with resource limits
-k run nginx --image=nginx:1.27 --limits=cpu=200m,memory=512Mi
+# There is no direct command to run pod with resource limits, instead you can use dry-run then edit file or use --overrides arg
+kubectl run nginx --image=nginx --overrides='{"spec":{"containers":[{"name":"nginx","image":"nginx","resources":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}]}}'
 
 # Pod with environment variables
 k run nginx --image=nginx:1.27 --env=LOG_LEVEL=debug --env=APP_ENV=prod


### PR DESCRIPTION
## What does this PR do?

  This PR fixes the pod resource limits example in `README.md`.

  The previous example used `k run ... --limits=...`, which is misleading for this use case. This change replaces it with a note explaining that there is no direct `kubectl run` command for setting pod
  resource requests/limits in that way, and adds a working `--overrides` example instead.

  ## Type of change

  - [x] Bug fix (broken command, invalid YAML, dead link)
  - [ ] New content (exercise, skeleton, troubleshooting scenario)
  - [x] Documentation update (README, comments, wording)
  - [ ] Chore (CI, tooling, repo housekeeping)

  ## Which CKA domain does this relate to?

  - [ ] Storage (10%)
  - [ ] Troubleshooting (30%)
  - [x] Workloads & Scheduling (15%)
  - [ ] Cluster Architecture, Installation & Configuration (25%)
  - [ ] Services & Networking (20%)
  - [ ] N/A

  ## Checklist

  - [ ] I ran `bash scripts/validate-local.sh` with no errors
  - [x] I tested any YAML/commands on Kubernetes v1.35
  - [x] I did not include real CKA exam questions
  - [x] I followed the writing style (first-person, casual, no emojis, no AI filler)
  - [x] I used the repo aliases (`k`, `$do`, `$now`) where applicable
  - [x] I verified all links point to existing files or valid URLs